### PR TITLE
Removed the dependency on Scalaz stream

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -32,7 +32,7 @@ object build extends Build {
   , base = file("saws-core")
   , settings = standardSettings ++ lib("core") ++ Seq[Settings](
       name := "saws-core"
-    ) ++ Seq[Settings](libraryDependencies ++= depend.scalaz ++ depend.aws ++ depend.scalazStream ++ depend.mundane ++ depend.testing)
+    ) ++ Seq[Settings](libraryDependencies ++= depend.scalaz ++ depend.aws ++ depend.mundane ++ depend.testing)
   )
 
   lazy val iam = Project(

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -5,8 +5,6 @@ object depend {
   val scalaz = Seq(  "org.scalaz" %% "scalaz-core"   % "7.1.0"
                    , "org.scalaz" %% "scalaz-effect" % "7.1.0")
 
-  val scalazStream = Seq("org.scalaz.stream" %% "scalaz-stream" % "0.5a")
-
   val mundaneVersion = "1.2.1-20150318063632-5e03317"
   val mundane = Seq(
       "com.ambiata" %% "mundane-io"

--- a/saws-s3/src/main/scala/com/ambiata/saws/s3/S3Address.scala
+++ b/saws-s3/src/main/scala/com/ambiata/saws/s3/S3Address.scala
@@ -17,7 +17,7 @@ import java.io._
 
 import scala.io.Codec
 
-import scalaz._, Scalaz._, effect._, stream._, concurrent.Task
+import scalaz._, Scalaz._, concurrent.Task
 import scalaz.\&/._
 
 case class SizedS3Address(s3: S3Address, size: Long)
@@ -287,7 +287,4 @@ object S3Address {
     (0 until numberOfParts.toInt).toList.map(part => (part * partSize, (part+1) * partSize - 1)) ++
       (if (lastPartSize == 0) List() else List((totalSize - lastPartSize, totalSize - 1)))
   }
-
-  def objectContentSink(f: InputStream => RIO[Unit]): Sink[Task, S3Object] =
-    io.channel((s3Object: S3Object) => RIO.toTask(f(s3Object.getObjectContent)))
 }

--- a/saws-s3/src/main/scala/com/ambiata/saws/s3/S3Prefix.scala
+++ b/saws-s3/src/main/scala/com/ambiata/saws/s3/S3Prefix.scala
@@ -7,7 +7,7 @@ import com.ambiata.mundane.io.{FilePath, DirPath, Directories}
 import com.ambiata.saws.core._
 import com.ambiata.saws.s3.{S3Operations => Op}
 
-import scalaz._, Scalaz._, effect._, stream._, concurrent.Task
+import scalaz._, Scalaz._, effect._, concurrent.Task
 
 import scala.collection.JavaConverters._
 import scala.annotation.tailrec


### PR DESCRIPTION
It was just used in one method which is never called in our codebase  and probably by no one using saws as far github search can tell. 

If we want to re-introduce some support for Scalaz stream it should be in a distinct module.

@markhibberd 