### PR TITLE
Added a CloudWatch module

### DIFF
--- a/bin/ci.branches
+++ b/bin/ci.branches
@@ -2,4 +2,4 @@
 
 source $(dirname $0)/config
 
-./sbt -Dsbt.log.noformat=true "; clean; stats; test-only -- exclude integration -- console junitxml; publish;  echo-version"
+./sbt -Dsbt.log.noformat=true "; clean; stats; test-only -- exclude integration -- console junitxml;  echo-version"

--- a/bin/ci.branches
+++ b/bin/ci.branches
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+source $(dirname $0)/config
+
+./sbt -Dsbt.log.noformat=true "; clean; stats; test-only -- exclude integration -- console junitxml; publish;  echo-version"

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -17,10 +17,10 @@ object depend {
       "com.ambiata" %% "mundane-testing"   % mundaneVersion)
 
   val disorder =
-    Seq("com.ambiata" %% "disorder" % "0.0.1-20150102073535-5c2d9d6" % "test")
+    Seq("com.ambiata" %% "disorder" % "0.0.1-20150824025853-fa03215" % "test")
 
   val aws = Seq(
-      "com.ambiata" %% "saws-aws"          % "1.2.1-20150326052208-6f1fc2a" intransitive()
+      "com.ambiata" %% "saws-aws"  % "1.2.1-20150326052208-6f1fc2a" intransitive()
     , "commons-logging"            % "commons-logging"     % "1.1.1"
     , "com.owtelse.codec"          % "base64"              % "1.0.6"
     , "javax.mail"                 % "mail"                % "1.4.7")

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/CloudWatchError.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/CloudWatchError.scala
@@ -1,0 +1,34 @@
+package com.ambiata.saws.cw
+
+import org.joda.time.DateTime
+
+/**
+ * Specific class of errors to codify what can happen
+ * when creating or uploading metrics
+ */
+sealed trait CloudWatchError
+
+case class TooManyDimensions(dimensions: List[MetricDimension]) extends CloudWatchError
+case class TooOldTimestamp(ts: DateTime, now: DateTime) extends CloudWatchError
+case class NamespaceFormatError(n: String) extends CloudWatchError
+case class DimensionsWithSameName(dimensions: List[MetricDimension]) extends CloudWatchError
+
+object CloudWatchError {
+
+  def render(e: CloudWatchError): String = e match {
+    case TooManyDimensions(dims) =>
+      s"Too many dimensions for the same metric. Must be <= 10. Got: ${dims.map(_.render).mkString("\n")}"
+
+    case TooOldTimestamp(timestamp, now) =>
+      s"Timestamp must specify a time within the past two weeks. Got: $timestamp, now is $now"
+
+    case DimensionsWithSameName(dimensions) =>
+      s"No metric may specify the same dimension name twice. Got: ${dimensions.map(_.render).mkString("\n")}"
+
+    case NamespaceFormatError(n) =>
+      s"The format for a namespace is [^:].* Got: $n"
+  }
+
+}
+
+

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/DataUnit.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/DataUnit.scala
@@ -1,0 +1,104 @@
+package com.ambiata.saws.cw
+
+import scalaz._, Scalaz._
+
+/**
+ * @see the definition of data units on
+ *      http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
+ */
+sealed trait DataUnit {
+  def render: String
+}
+case object NoneDataUnit       extends DataUnit { def render = "None"               }
+case object Count              extends DataUnit { def render = "Count"              }
+case object CountPerSecond     extends DataUnit { def render = "Count/Second"       }
+case object Percent            extends DataUnit { def render = "Percent"            }
+case object Bytes              extends DataUnit { def render = "Bytes"              }
+case object Kilobytes          extends DataUnit { def render = "Kilobytes"          }
+case object Megabytes          extends DataUnit { def render = "Megabytes"          }
+case object Gigabytes          extends DataUnit { def render = "Gigabytes"          }
+case object Terabytes          extends DataUnit { def render = "Terabytes"          }
+case object Bits               extends DataUnit { def render = "Bits"               }
+case object Kilobits           extends DataUnit { def render = "Kilobits"           }
+case object Megabits           extends DataUnit { def render = "Megabits"           }
+case object Gigabits           extends DataUnit { def render = "Gigabits"           }
+case object Terabits           extends DataUnit { def render = "Terabits"           }
+case object Seconds            extends DataUnit { def render = "Seconds"            }
+case object Microseconds       extends DataUnit { def render = "Microseconds"       }
+case object Milliseconds       extends DataUnit { def render = "Milliseconds"       }
+case object BytesPerSecond     extends DataUnit { def render = "Bytes/Second"       }
+case object KilobytesPerSecond extends DataUnit { def render = "Kilobytes/Second"   }
+case object MegabytesPerSecond extends DataUnit { def render = "Megabytes/Second"   }
+case object GigabytesPerSecond extends DataUnit { def render = "Gigabytes/Second"   }
+case object TerabytesPerSecond extends DataUnit { def render = "Terabytes/Second"   }
+case object BitsPerSecond      extends DataUnit { def render = "Bits/Second"        }
+case object KilobitsPerSecond  extends DataUnit { def render = "Kilobits/Second"    }
+case object MegabitsPerSecond  extends DataUnit { def render = "Megabits/Second"    }
+case object GigabitsPerSecond  extends DataUnit { def render = "Gigabits/Second"    }
+case object TerabitsPerSecond  extends DataUnit { def render = "Terabits/Second"    }
+
+object DataUnit {
+
+  def allUnits: List[DataUnit] = List(
+      NoneDataUnit
+    , Count
+    , CountPerSecond
+    , Percent
+    , Bytes
+    , Kilobytes
+    , Megabytes
+    , Gigabytes
+    , Terabytes
+    , Bits
+    , Kilobits
+    , Megabits
+    , Gigabits
+    , Terabits
+    , Seconds
+    , Microseconds
+    , Milliseconds
+    , BytesPerSecond
+    , KilobytesPerSecond
+    , MegabytesPerSecond
+    , GigabytesPerSecond
+    , TerabytesPerSecond
+    , BitsPerSecond
+    , KilobitsPerSecond
+    , MegabitsPerSecond
+    , GigabitsPerSecond
+    , TerabitsPerSecond
+  )
+
+  def parse(s: String): String \/ DataUnit = s match {
+    case "None"               => NoneDataUnit.right
+    case "Count"              => Count.right
+    case "Count/Second"       => CountPerSecond.right
+    case "Percent"            => Percent.right
+    case "Bytes"              => Bytes.right
+    case "Kilobytes"          => Kilobytes.right
+    case "Megabytes"          => Megabytes.right
+    case "Gigabytes"          => Gigabytes.right
+    case "Terabytes"          => Terabytes.right
+    case "Bits"               => Bits.right
+    case "Kilobits"           => Kilobits.right
+    case "Megabits"           => Megabits.right
+    case "Gigabits"           => Gigabits.right
+    case "Terabits"           => Terabits.right
+    case "Seconds"            => Seconds.right
+    case "Microseconds"       => Microseconds.right
+    case "Milliseconds"       => Milliseconds.right
+    case "Bytes/Second"       => BytesPerSecond.right
+    case "Kilobytes/Second"   => KilobytesPerSecond.right
+    case "Megabytes/Second"   => MegabytesPerSecond.right
+    case "Gigabytes/Second"   => GigabytesPerSecond.right
+    case "Terabytes/Second"   => TerabytesPerSecond.right
+    case "Bits/Second"        => BitsPerSecond.right
+    case "Kilobits/Second"    => KilobitsPerSecond.right
+    case "Megabits/Second"    => MegabitsPerSecond.right
+    case "Gigabits/Second"    => GigabitsPerSecond.right
+    case "Terabits/Second"    => TerabitsPerSecond.right
+    case s                    => s"Not a valid data unit: $s".left
+  }
+
+}
+

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimension.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimension.scala
@@ -17,4 +17,8 @@ case class MetricDimension(name: String, value: String) extends {
     s"$name=$value"
 }
 
+object MetricDimension {
+  def fromDimension(d: Dimension): MetricDimension =
+    MetricDimension(d.getName, d.getValue)
+}
 

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimension.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimension.scala
@@ -1,0 +1,20 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.com.amazonaws.services.cloudwatch.model.Dimension
+
+/**
+ * Scala-friendly Dimension class
+ */
+case class MetricDimension(name: String, value: String) extends {
+  def toDimension: Dimension = {
+    val d: Dimension = new Dimension
+    d.setName(name)
+    d.setValue(value)
+    d
+  }
+
+  def render: String =
+    s"$name=$value"
+}
+
+

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimensions.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimensions.scala
@@ -1,0 +1,83 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.com.amazonaws.services.cloudwatch.model.MetricDatum
+import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
+import MetricDimensions._
+
+/**
+ * List of metric dimensions
+ *
+ * They can be applied in different ways to a list of data points
+ */
+sealed trait MetricDimensions {
+
+  def addDimension(d: MetricDimension): MetricDimensions
+
+  def addDimensions(ds: List[MetricDimension]): MetricDimensions =
+    ds.foldLeft(this)(_ addDimension _)
+
+  def dimensions: List[MetricDimension]
+
+  def size: Int =
+    dimensions.size
+
+  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum]
+}
+
+object MetricDimensions {
+
+  /** check if a list of dimensions is respecting the CloudWatch constraints */
+  def checkDimensions(dimensions: MetricDimensions): CloudWatchError \/ MetricDimensions = {
+    val ds = dimensions.dimensions
+
+    if (ds.groupBy(_.name).size != ds.size) (DimensionsWithSameName(ds): CloudWatchError).left[MetricDimensions]
+    else if (ds.size > 10)                  (TooManyDimensions(ds): CloudWatchError).left[MetricDimensions]
+    else                                    dimensions.right
+  }
+
+}
+
+/**
+ * Metric dimensions are set on metric datum
+ * as per the number of inits in the list
+ *
+ * This allows metric data to be aggregated across dimensions
+ */
+case class PrefixesMetricDimensions(dimensions: List[MetricDimension]) extends MetricDimensions {
+  def addDimension(d: MetricDimension): MetricDimensions =
+    copy(dimensions = dimensions :+ d)
+
+  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum] =
+    metricData.flatMap { md =>
+      dimensions.inits.filter(_.nonEmpty).map { dims =>
+        cloneMetricData(md).withDimensions(dims.map(_.toDimension).asJavaCollection)
+      }.toList
+    }
+
+  /** the beauty of mutability ... */
+  def cloneMetricData(md: MetricDatum): MetricDatum =
+    (new MetricDatum)
+      .withDimensions(md.getDimensions)
+      .withMetricName(md.getMetricName)
+      .withStatisticValues(md.getStatisticValues)
+      .withUnit(md.getUnit)
+      .withValue(md.getValue)
+      .withTimestamp(md.getTimestamp)
+
+}
+
+/**
+ * Exact metric dimensions.
+ *
+ * The full list of dimensions is attached to a metric data point
+ */
+case class ExactMetricDimensions(dimensions: List[MetricDimension]) extends MetricDimensions {
+  def addDimension(d: MetricDimension): MetricDimensions =
+    copy(dimensions = dimensions :+ d)
+
+  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum] =
+    metricData.map(_.withDimensions(dimensions.map(_.toDimension).asJavaCollection))
+
+}
+

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimensions.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/MetricDimensions.scala
@@ -3,57 +3,34 @@ package com.ambiata.saws.cw
 import com.ambiata.com.amazonaws.services.cloudwatch.model.MetricDatum
 import scala.collection.JavaConverters._
 import scalaz._, Scalaz._
-import MetricDimensions._
-
-/**
- * List of metric dimensions
- *
- * They can be applied in different ways to a list of data points
- */
-sealed trait MetricDimensions {
-
-  def addDimension(d: MetricDimension): MetricDimensions
-
-  def addDimensions(ds: List[MetricDimension]): MetricDimensions =
-    ds.foldLeft(this)(_ addDimension _)
-
-  def dimensions: List[MetricDimension]
-
-  def size: Int =
-    dimensions.size
-
-  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum]
-}
 
 object MetricDimensions {
 
   /** check if a list of dimensions is respecting the CloudWatch constraints */
-  def checkDimensions(dimensions: MetricDimensions): CloudWatchError \/ MetricDimensions = {
-    val ds = dimensions.dimensions
+  def checkMetricDataDimensions(dimensions: List[MetricDatum]): CloudWatchError \/ List[MetricDatum] =
+    dimensions.traverseU(checkMetricDatumDimensions)
 
-    if (ds.groupBy(_.name).size != ds.size) (DimensionsWithSameName(ds): CloudWatchError).left[MetricDimensions]
-    else if (ds.size > 10)                  (TooManyDimensions(ds): CloudWatchError).left[MetricDimensions]
-    else                                    dimensions.right
+  /** check if a list of dimensions is respecting the CloudWatch constraints */
+  def checkMetricDatumDimensions(md: MetricDatum): CloudWatchError \/ MetricDatum = {
+    val ds = md.getDimensions.asScala.map(MetricDimension.fromDimension).toList
+
+    if (ds.groupBy(_.name).size != ds.size) (DimensionsWithSameName(ds): CloudWatchError).left[MetricDatum]
+    else if (ds.size > 10)                  (TooManyDimensions(ds): CloudWatchError).left[MetricDatum]
+    else                                    md.right
   }
 
-}
-
-/**
- * Metric dimensions are set on metric datum
- * as per the number of inits in the list
- *
- * This allows metric data to be aggregated across dimensions
- */
-case class PrefixesMetricDimensions(dimensions: List[MetricDimension]) extends MetricDimensions {
-  def addDimension(d: MetricDimension): MetricDimensions =
-    copy(dimensions = dimensions :+ d)
-
-  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum] =
-    metricData.flatMap { md =>
-      dimensions.inits.filter(_.nonEmpty).map { dims =>
-        cloneMetricData(md).withDimensions(dims.map(_.toDimension).asJavaCollection)
-      }.toList
+  def setDimensionsPrefixes(dimensions: List[MetricDimension]): List[MetricDatum] => List[MetricDatum] =
+    (metricData: List[MetricDatum]) => {
+      metricData.flatMap { md =>
+        dimensions.inits.filter(_.nonEmpty).map { dims =>
+          cloneMetricData(md).withDimensions(dims.map(_.toDimension).asJavaCollection)
+        }.toList
+      }
     }
+
+  def setAllDimensions(dimensions: List[MetricDimension]): List[MetricDatum] => List[MetricDatum] =
+    (metricData: List[MetricDatum]) =>
+      metricData.map(_.withDimensions(dimensions.map(_.toDimension).asJavaCollection))
 
   /** the beauty of mutability ... */
   def cloneMetricData(md: MetricDatum): MetricDatum =
@@ -66,18 +43,3 @@ case class PrefixesMetricDimensions(dimensions: List[MetricDimension]) extends M
       .withTimestamp(md.getTimestamp)
 
 }
-
-/**
- * Exact metric dimensions.
- *
- * The full list of dimensions is attached to a metric data point
- */
-case class ExactMetricDimensions(dimensions: List[MetricDimension]) extends MetricDimensions {
-  def addDimension(d: MetricDimension): MetricDimensions =
-    copy(dimensions = dimensions :+ d)
-
-  def setDimensions(metricData: List[MetricDatum]): List[MetricDatum] =
-    metricData.map(_.withDimensions(dimensions.map(_.toDimension).asJavaCollection))
-
-}
-

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/Namespace.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/Namespace.scala
@@ -1,0 +1,33 @@
+package com.ambiata.saws.cw
+
+import scalaz._, Scalaz._
+
+/**
+ * Namespace for uploading metrics
+ */
+case class Namespace private(name: String) extends AnyVal {
+  def append(other: Namespace): Namespace =
+    Namespace(name+"/"+other.name)
+}
+
+object Namespace {
+
+  /**
+   * Namespaces must respect the CloudWatch format. Supposedly
+   * anything matching "[^:].*" but actually non-ascii characters are not supported
+   *
+   * @see http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html
+   */
+  def fromString(n: String): CloudWatchError \/ Namespace =
+    if (n.forall(isAsciiNoControl)) Namespace(n).right
+    else                            NamespaceFormatError(n).left
+
+  def isAsciiNoControl(c: Char): Boolean = {
+    val intCode = Char.char2int(c)
+    intCode >= 32 && intCode <= 126
+  }
+
+  def unsafe(n: String): Namespace =
+    Namespace(n)
+}
+

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/Statistics.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/Statistics.scala
@@ -1,0 +1,14 @@
+package com.ambiata.saws.cw
+
+/**
+ * Statistics collected by applications at the end of their run
+ */
+case class Statistics(stats: Map[String, StatisticsData]) {
+
+  def isEmpty: Boolean =
+    stats.isEmpty
+
+}
+
+/** individual piece of statistic */
+case class StatisticsData(value: Double, unit: DataUnit)

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/StatisticsMetrics.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/StatisticsMetrics.scala
@@ -1,0 +1,106 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.com.amazonaws.services.cloudwatch.model._
+import com.ambiata.mundane.control.RIO
+import com.ambiata.saws.core.Clients
+import org.joda.time._
+import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
+import StatisticsMetrics._
+
+/**
+ * This class groups statistics gathered for a given application which we want to
+ * publish as CloudWatch metrics.
+ *
+ * The timestamp is considered global for all the data points
+ * and should correspond to the end of the application run
+ */
+case class StatisticsMetrics(statistics: Statistics, dimensions: MetricDimensions, timestamp: DateTime) {
+
+  def isEmpty: Boolean =
+    statistics.isEmpty
+
+  /** add one more dimension */
+  def addDimension(d: MetricDimension): StatisticsMetrics =
+    copy(dimensions = dimensions.addDimension(d))
+
+  /**
+   * @return statistics as metric datum objects for CloudWatch
+   *         fail if there are more than 10 dimensions
+   *         or if the timestamp is more than 2 weeks in the past
+   */
+  def toMetricData: RIO[CloudWatchError \/ List[MetricDatum]] =
+    checkTimestamp(timestamp).map { ts =>
+      for {
+        tstamp <- ts
+        ds     <- MetricDimensions.checkDimensions(dimensions)
+        mds    =  ds.setDimensions(statistics.stats.toList.map(createMetricDatum))
+      } yield mds.map(setTimestamp(tstamp))
+    }
+
+}
+
+object StatisticsMetrics {
+
+  /**
+   * Upload metrics to CloudWatch
+   */
+  def upload(statistics: StatisticsMetrics, namespace: Namespace): RIO[Unit] = {
+    val action =
+      // if there are no statistics we should return ok right away
+      // otherwise the request will fail
+      if (statistics.isEmpty) EitherT.right(RIO.ok(()))
+      else
+        for {
+          rs <- makePutMetricDataRequests(statistics, namespace)
+          _  <- rs.traverseU(r => EitherT.right[RIO, CloudWatchError, Unit](RIO.safe(Clients.cw.putMetricData(r))))
+        } yield ()
+
+    action.run.flatMap(_.fold(e => RIO.fail(CloudWatchError.render(e)), RIO.ok))
+  }
+
+  /**
+   * Create requests to publish metric data from statistics
+   *
+   * Each request can only have 20 metrics maximum
+   */
+  def makePutMetricDataRequests(stats: StatisticsMetrics, namespace: Namespace): EitherT[RIO, CloudWatchError, List[PutMetricDataRequest]] =
+    for {
+      metrics <- EitherT(stats.toMetricData)
+      grouped =  metrics.grouped(20).toList
+    } yield grouped.map(createPutRequest(namespace))
+
+  /**
+   * create a put request for a list of maximum 20 metrics
+   */
+  def createPutRequest(namespace: Namespace)(metrics: List[MetricDatum]): PutMetricDataRequest = {
+    val putRequest: PutMetricDataRequest = new PutMetricDataRequest
+    putRequest.withNamespace(namespace.name)
+    putRequest.withMetricData(metrics.asJavaCollection)
+    putRequest
+  }
+
+  def checkTimestamp(timestamp: DateTime): RIO[CloudWatchError \/ DateTime] =
+    RIO.safe(DateTime.now) map { now =>
+      if (Weeks.weeksBetween(timestamp, now).getWeeks <= 2)
+        timestamp.right
+      else
+        TooOldTimestamp(timestamp, now).left
+    }
+
+  /** create a metric data point with no timestamp nor dimensions */
+  def createMetricDatum(nd: (String, StatisticsData)): MetricDatum = {
+    val (name, data) = nd
+    val metric = new MetricDatum
+    metric.setMetricName(name)
+    metric.setValue(data.value)
+    metric.setUnit(data.unit.render)
+    metric
+  }
+
+  def setTimestamp(ts: DateTime) = { md: MetricDatum =>
+    md.setTimestamp(ts.toDate)
+    md
+  }
+
+}

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/StatisticsMetrics.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/StatisticsMetrics.scala
@@ -15,14 +15,10 @@ import StatisticsMetrics._
  * The timestamp is considered global for all the data points
  * and should correspond to the end of the application run
  */
-case class StatisticsMetrics(statistics: Statistics, dimensions: MetricDimensions, timestamp: DateTime) {
+case class StatisticsMetrics(statistics: Statistics, setDimensions: List[MetricDatum] => List[MetricDatum], timestamp: DateTime) {
 
   def isEmpty: Boolean =
     statistics.isEmpty
-
-  /** add one more dimension */
-  def addDimension(d: MetricDimension): StatisticsMetrics =
-    copy(dimensions = dimensions.addDimension(d))
 
   /**
    * @return statistics as metric datum objects for CloudWatch
@@ -33,8 +29,8 @@ case class StatisticsMetrics(statistics: Statistics, dimensions: MetricDimension
     checkTimestamp(timestamp).map { ts =>
       for {
         tstamp <- ts
-        ds     <- MetricDimensions.checkDimensions(dimensions)
-        mds    =  ds.setDimensions(statistics.stats.toList.map(createMetricDatum))
+        mds    =  setDimensions(statistics.stats.toList.map(createMetricDatum))
+        ds     <- MetricDimensions.checkMetricDataDimensions(mds)
       } yield mds.map(setTimestamp(tstamp))
     }
 

--- a/saws-cw/src/main/scala/com/ambiata/saws/cw/package.scala
+++ b/saws-cw/src/main/scala/com/ambiata/saws/cw/package.scala
@@ -1,0 +1,43 @@
+package com.ambiata.saws
+
+import com.ambiata.mundane.reflect.MacrosCompat
+
+package object cw extends MacrosCompat {
+
+  /** the qualification of NamespaceSyntax seems to be necessary here */
+  implicit def stringToNamespaceSyntax(s: String): com.ambiata.saws.cw.NamespaceSyntax =
+    macro createNamespaceSyntax
+
+  def createNamespaceSyntax(c: Context)(s: c.Expr[String]): c.Expr[com.ambiata.saws.cw.NamespaceSyntax] = {
+    import c.universe._
+    s match {
+      case Expr(Literal(Constant(v: String))) => c.Expr(q"new NamespaceSyntax(${createNamespaceFromString(c)(v)})")
+      case _ => c.abort(c.enclosingPosition, s"Not a literal ${showRaw(s)}")
+    }
+  }
+
+  implicit class NamespaceSyntax(ns: Namespace) {
+    def /(other: Namespace): Namespace =
+      ns append other
+  }
+
+  implicit def ToNamespace(s: String): Namespace =
+    macro create
+
+  def create(c: Context)(s: c.Expr[String]): c.Expr[Namespace] = {
+    import c.universe._
+    s match {
+      case Expr(Literal(Constant(v: String))) => createNamespaceFromString(c)(v)
+      case _ => c.abort(c.enclosingPosition, s"Not a literal ${showRaw(s)}")
+    }
+  }
+
+  private def createNamespaceFromString(c: Context)(s: String): c.Expr[Namespace] = {
+    import c.universe._
+    Namespace.fromString(s).fold(
+      e  => c.abort(c.enclosingPosition, CloudWatchError.render(e)),
+      ns => c.Expr(q"Namespace.unsafe(${ns.name})")
+    )
+  }
+
+}

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/Arbitraries.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/Arbitraries.scala
@@ -57,19 +57,20 @@ object Arbitraries {
   def genDimensions: Gen[List[MetricDimension]] =
     Gen.nonEmptyListOf(arbitrary[MetricDimension]).map(_.groupBy(_.name).map(_._2.head).toList.take(10))
 
+  type MetricDimensions = List[MetricDatum] => List[MetricDatum]
   implicit def MetricDimensionsArbitrary: Arbitrary[MetricDimensions] =
     Arbitrary {
       for {
         b  <- arbitrary[Boolean]
         ds <- genDimensions
-      } yield if (b) ExactMetricDimensions(ds) else PrefixesMetricDimensions(ds)
+      } yield if (b) MetricDimensions.setAllDimensions(ds) else MetricDimensions.setDimensionsPrefixes(ds)
     }
 
-  implicit def ExactMetricDimensionsArbitrary: Arbitrary[ExactMetricDimensions] =
-    Arbitrary(genDimensions.map(ExactMetricDimensions.apply))
+  def exactMetricDimensions: Gen[MetricDimensions] =
+    genDimensions.map(MetricDimensions.setAllDimensions)
 
-  implicit def AggregateMetricDimensionsArbitrary: Arbitrary[PrefixesMetricDimensions] =
-    Arbitrary(genDimensions.map(PrefixesMetricDimensions.apply))
+  implicit def prefixesMetricDimensions: Gen[MetricDimensions] =
+    genDimensions.map(MetricDimensions.setDimensionsPrefixes)
 
   implicit def MetricDatumArbitrary: Arbitrary[MetricDatum] =
     Arbitrary {

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/Arbitraries.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/Arbitraries.scala
@@ -1,0 +1,91 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.com.amazonaws.services.cloudwatch.model.MetricDatum
+import com.ambiata.disorder._
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen._
+import org.scalacheck._
+
+object Arbitraries {
+
+  implicit def ArbitraryDataUnit: Arbitrary[DataUnit] =
+    Arbitrary(Gen.oneOf(DataUnit.allUnits))
+
+
+  implicit def StatisticsMetricsArbitrary: Arbitrary[StatisticsMetrics] =
+    Arbitrary {
+      for {
+        stats <- arbitrary[Statistics]
+        ds    <- arbitrary[MetricDimensions]
+        ts    <- arbitrary[Timestamp]
+      } yield StatisticsMetrics(stats, ds, timestamp = ts.value)
+    }
+
+  // statistics must not be empty
+  implicit def StatisticsArbitrary: Arbitrary[Statistics] =
+    Arbitrary { sized { n =>
+        for {
+          names <- Gen.oneOf(Corpus.muppets.permutations.take(n+1).toSeq)
+          data  <- listOfN(n+1, arbitrary[StatisticsData])
+        } yield Statistics(Map(names zip data: _*))
+      }
+    }
+
+  implicit def StatisticsDataArbitrary: Arbitrary[StatisticsData] =
+    Arbitrary {
+      for {
+        value <- arbitrary[PositiveInt].map(_.value.toDouble)
+        unit  <- arbitrary[DataUnit]
+      } yield StatisticsData(value, unit)
+    }
+
+  implicit def NamespaceArbitrary: Arbitrary[Namespace] =
+    Arbitrary(S.words.map(Namespace.fromString).map(_.toOption).suchThat(_.isDefined).map(_.get))
+
+  implicit def MetricDimensionArbitrary: Arbitrary[MetricDimension] =
+    Arbitrary {
+      for {
+        n <- Gen.oneOf(Corpus.simpsons)
+        v <- Gen.oneOf(Corpus.weather)
+      } yield MetricDimension(n, v)
+    }
+
+  // make sure the dimension names are unique
+  // and the total number of dimensions is less than 10
+  def genDimensions: Gen[List[MetricDimension]] =
+    Gen.nonEmptyListOf(arbitrary[MetricDimension]).map(_.groupBy(_.name).map(_._2.head).toList.take(10))
+
+  implicit def MetricDimensionsArbitrary: Arbitrary[MetricDimensions] =
+    Arbitrary {
+      for {
+        b  <- arbitrary[Boolean]
+        ds <- genDimensions
+      } yield if (b) ExactMetricDimensions(ds) else PrefixesMetricDimensions(ds)
+    }
+
+  implicit def ExactMetricDimensionsArbitrary: Arbitrary[ExactMetricDimensions] =
+    Arbitrary(genDimensions.map(ExactMetricDimensions.apply))
+
+  implicit def AggregateMetricDimensionsArbitrary: Arbitrary[PrefixesMetricDimensions] =
+    Arbitrary(genDimensions.map(PrefixesMetricDimensions.apply))
+
+  implicit def MetricDatumArbitrary: Arbitrary[MetricDatum] =
+    Arbitrary {
+      for {
+        n  <- Gen.oneOf(Corpus.simpsons)
+        sd <- arbitrary[StatisticsData]
+      } yield StatisticsMetrics.createMetricDatum((n, sd))
+    }
+
+  implicit def DateTimeArbitrary: Arbitrary[DateTime] =
+    Arbitrary(arbitrary[PositiveLongSmall].map(l => new DateTime(l.value).withMillisOfDay(0).withZone(UTC)))
+
+  implicit def TimestampArbitrary: Arbitrary[Timestamp] =
+    Arbitrary(arbitrary[PositiveLongSmall].map(l => Timestamp(DateTime.now.minusMillis(l.value.toInt).withMillisOfDay(0).withZone(UTC))))
+
+  case class Timestamp(value: DateTime)
+}
+
+

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/DataUnitSpec.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/DataUnitSpec.scala
@@ -1,0 +1,17 @@
+package com.ambiata.saws.cw
+
+import org.specs2._
+import org.scalacheck._
+import Arbitraries._
+
+class DataUnitSpec extends Specification with ScalaCheck { def is = s2"""
+
+  Parsing / rendering $roundTrip
+
+"""
+
+  def roundTrip = prop { unit: DataUnit =>
+    DataUnit.parse(unit.render).toEither must beRight(unit)
+  }
+
+}

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/MetricDimensionsSpec.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/MetricDimensionsSpec.scala
@@ -1,0 +1,46 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.com.amazonaws.services.cloudwatch.model.MetricDatum
+import org.specs2._
+import Arbitraries._
+import scala.collection.JavaConverters._
+
+class MetricDimensionsSpec extends Specification with ScalaCheck { def is = s2"""
+
+ Metric dimensions have some constraints
+  only a maximum of 10 dimensions is allowed for metric data $dimensions
+  dimension names must be unique                             $dimensionNames
+
+ There are 2 ways to set dimensions on a metric data point
+   apply all the dimensions at once                      $exact
+   apply all non-empty prefixes of the dimensions list   $prefixes
+
+"""
+
+  def dimensions = prop { dimensions: MetricDimensions =>
+    MetricDimensions.checkDimensions(dimensions).toEither must beLeft { e: CloudWatchError =>
+      e must beLike { case TooManyDimensions(_) => ok }
+    }.when(dimensions.size > 10)
+  }
+
+  def dimensionNames = prop { dimensions: MetricDimensions =>
+    // duplicate the dimensions
+    val ds = dimensions.addDimensions(dimensions.dimensions)
+
+    MetricDimensions.checkDimensions(ds).toEither must beLeft { e: CloudWatchError =>
+      e must beLike { case DimensionsWithSameName(_) => ok }
+    }.when(ds.size > 0)
+  }
+
+  def exact = prop { (ds: ExactMetricDimensions, md: List[MetricDatum]) =>
+    ds.setDimensions(md) must contain { d: MetricDatum =>
+      d.getDimensions must haveSize(ds.size)
+    }.forall
+  }
+
+  def prefixes = prop { (ds: PrefixesMetricDimensions, md: MetricDatum) =>
+    ds.setDimensions(List(md)).map(_.getDimensions.asScala.toList) must_==
+      ds.dimensions.map(_.toDimension).inits.toList.filter(_.nonEmpty)
+  }
+}
+

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/NamespaceSpec.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/NamespaceSpec.scala
@@ -1,0 +1,22 @@
+package com.ambiata.saws.cw
+
+import org.specs2._
+import Arbitraries._
+
+class NamespaceSpec extends Specification with ScalaCheck { def is = s2"""
+
+ namespace literals must compile if they are correct $literals
+ append namespaces  $append
+
+"""
+
+  def literals = {
+    val ns: Namespace = "namespace"
+    "namespace1" / "namespace2"
+    ok
+  }
+
+  def append = prop { (ns1: Namespace, ns2: Namespace) =>
+    (ns1 append ns2).name === (ns1.name + "/" + ns2.name)
+  }
+}

--- a/saws-cw/src/test/scala/com/ambiata/saws/cw/StatisticsMetricsSpec.scala
+++ b/saws-cw/src/test/scala/com/ambiata/saws/cw/StatisticsMetricsSpec.scala
@@ -1,0 +1,23 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.disorder.PositiveIntSmall
+import org.joda.time.DateTime
+import org.specs2.{ScalaCheck, Specification}
+import Arbitraries._
+import com.ambiata.mundane.testing.RIOMatcher._
+
+import scalaz.\/
+
+class StatisticsMetricsSpec extends Specification with ScalaCheck { def is = s2"""
+
+  the timestamp be not be older than 2 weeks  $timestamp
+
+"""
+
+  def timestamp = prop { n: PositiveIntSmall =>
+    StatisticsMetrics.checkTimestamp(DateTime.now.minusWeeks(n.value)) must beOkLike { ts: CloudWatchError \/ DateTime =>
+      ts.toEither must beLeft
+    }.when(n.value >= 3)
+  }
+
+}

--- a/saws-testing/src/test/scala/com/ambiata/saws/cw/StatisticsMetricsIntegrationSpec.scala
+++ b/saws-testing/src/test/scala/com/ambiata/saws/cw/StatisticsMetricsIntegrationSpec.scala
@@ -1,0 +1,18 @@
+package com.ambiata.saws.cw
+
+import com.ambiata.mundane.testing.RIOMatcher._
+import com.ambiata.saws.testing.IntegrationSpec
+import org.specs2._
+import Arbitraries._
+
+class StatisticsMetricsIntegrationSpec extends Specification with ScalaCheck with IntegrationSpec { def is = s2"""
+
+  uploading correct statistics metrics should succeed $upload
+
+"""
+
+  def upload = prop { stats: StatisticsMetrics =>
+    StatisticsMetrics.upload(stats, "test") must beOk
+  }.set(minTestsOk = 5)
+}
+

--- a/saws-testing/src/test/scala/com/ambiata/saws/testing/IntegrationSpec.scala
+++ b/saws-testing/src/test/scala/com/ambiata/saws/testing/IntegrationSpec.scala
@@ -1,8 +1,8 @@
 package com.ambiata.saws.testing
 
-import org.specs2.Specification
+import org.specs2._
 import org.specs2.specification.Fragments
 
-abstract class IntegrationSpec extends Specification {
+trait IntegrationSpec extends SpecificationLike {
   override def map(fs: =>Fragments) = section("integration", "aws") ^ super.map(fs)
 }

--- a/sbt
+++ b/sbt
@@ -1,70 +1,61 @@
 #!/usr/bin/env bash
 #
 # A more capable sbt runner, coincidentally also called sbt.
-# Author: Paul Phillips <paulp@typesafe.com>
+# Author: Paul Phillips <paulp@improving.org>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.12.2
-declare -r sbt_snapshot_version=0.13.0-SNAPSHOT
+declare -r sbt_release_version="0.13.9"
+declare -r sbt_unreleased_version="0.13.9"
+declare -r buildProps="project/build.properties"
 
-declare sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir
-declare scala_version java_home sbt_explicit_version
-declare verbose debug quiet noshare batch trace_level log_level
+declare sbt_jar sbt_dir sbt_create sbt_version
+declare scala_version sbt_explicit_version
+declare verbose noshare batch trace_level log_level
+declare sbt_saved_stty debugUs
 
-for arg in "$@"; do
-  case $arg in
-    -q|-quiet)  quiet=true ;;
-            *)             ;;
-  esac
-done
+echoerr () { echo >&2 "$@"; }
+vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
 
+# spaces are possible, e.g. sbt.version = 0.13.0
 build_props_sbt () {
-  if [[ -r project/build.properties ]]; then
-    versionLine=$(grep ^sbt.version project/build.properties)
-    versionString=${versionLine##sbt.version=}
-    echo "$versionString"
-  fi
+  [[ -r "$buildProps" ]] && \
+    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
 }
 
 update_build_props_sbt () {
   local ver="$1"
-  local old=$(build_props_sbt)
+  local old="$(build_props_sbt)"
 
-  if [[ $ver == $old ]]; then
-    return
-  elif [[ -r project/build.properties ]]; then
-    perl -pi -e "s/^sbt\.version=.*\$/sbt.version=${ver}/" project/build.properties
-    grep -q '^sbt.version=' project/build.properties || echo "sbt.version=${ver}" >> project/build.properties
+  [[ -r "$buildProps" ]] && [[ "$ver" != "$old" ]] && {
+    perl -pi -e "s/^sbt\.version\b.*\$/sbt.version=${ver}/" "$buildProps"
+    grep -q '^sbt.version[ =]' "$buildProps" || printf "\nsbt.version=%s\n" "$ver" >> "$buildProps"
 
-    echo !!!
-    echo !!! Updated file project/build.properties setting sbt.version to: $ver
-    echo !!! Previous value was: $old
-    echo !!!
-  fi
+    vlog "!!!"
+    vlog "!!! Updated file $buildProps setting sbt.version to: $ver"
+    vlog "!!! Previous value was: $old"
+    vlog "!!!"
+  }
 }
 
-sbt_version () {
-  if [[ -n $sbt_explicit_version ]]; then
-    echo $sbt_explicit_version
-  else
-    local v=$(build_props_sbt)
-    if [[ -n $v ]]; then
-      echo $v
-    else
-      echo $sbt_release_version
-    fi
-  fi
+set_sbt_version () {
+  sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
+  [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
+  export sbt_version
 }
 
-echoerr () {
-  [[ -z $quiet ]] && echo "$@" >&2
+# restore stty settings (echo in particular)
+onSbtRunnerExit() {
+  [[ -n "$sbt_saved_stty" ]] || return
+  vlog ""
+  vlog "restoring stty: $sbt_saved_stty"
+  stty "$sbt_saved_stty"
+  unset sbt_saved_stty
 }
-vlog () {
-  [[ $verbose || $debug ]] && echoerr "$@"
-}
-dlog () {
-  [[ $debug ]] && echoerr "$@"
-}
+
+# save stty and trap exit, to ensure echo is reenabled if we are interrupted.
+trap onSbtRunnerExit EXIT
+sbt_saved_stty="$(stty -g 2>/dev/null)"
+vlog "Saved stty: $sbt_saved_stty"
 
 # this seems to cover the bases on OSX, and someone will
 # have to tell me about the others.
@@ -72,11 +63,11 @@ get_script_path () {
   local path="$1"
   [[ -L "$path" ]] || { echo "$path" ; return; }
 
-  local target=$(readlink "$path")
+  local target="$(readlink "$path")"
   if [[ "${target:0:1}" == "/" ]]; then
     echo "$target"
   else
-    echo "$(dirname $path)/$target"
+    echo "${path%/*}/$target"
   fi
 }
 
@@ -86,30 +77,45 @@ die() {
 }
 
 make_url () {
-  groupid="$1"
-  category="$2"
-  version="$3"
+  version="$1"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  case "$version" in
+        0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-0.7.7.jar" ;;
+      0.10.* ) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    0.11.[12]) echo "$sbt_launch_repo/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+            *) echo "$sbt_launch_repo/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+  esac
 }
 
-declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m -Xmx1g -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+init_default_option_file () {
+  local overriding_var="${!1}"
+  local default_file="$2"
+  if [[ ! -r "$default_file" && "$overriding_var" =~ ^@(.*)$ ]]; then
+    local envvar_file="${BASH_REMATCH[1]}"
+    if [[ -r "$envvar_file" ]]; then
+      default_file="$envvar_file"
+    fi
+  fi
+  echo "$default_file"
+}
+
+declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
+declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.0"
+declare -r latest_210="2.10.5"
+declare -r latest_211="2.11.7"
 
-declare -r script_path=$(get_script_path "$BASH_SOURCE")
-declare -r script_dir="$(dirname $script_path)"
-declare -r script_name="$(basename $script_path)"
+declare -r script_path="$(get_script_path "$BASH_SOURCE")"
+declare -r script_name="${script_path##*/}"
 
 # some non-read-onlies set with defaults
-declare java_cmd=java
-declare sbt_launch_dir="$script_dir/.lib"
-declare sbt_universal_launcher="$script_dir/lib/sbt-launch.jar"
-declare sbt_jar=$sbt_universal_launcher
-declare sbt_opts_file=.sbtopts
-declare jvm_opts_file=.jvmopts
+declare java_cmd="java"
+declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
+declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
+declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args
@@ -120,90 +126,108 @@ declare -a sbt_commands
 # args to jvm/sbt via files or environment variables
 declare -a extra_jvm_opts extra_sbt_opts
 
-# if set, use JAVA_HOME over java found in path
-[[ -e "$JAVA_HOME/bin/java" ]] && java_cmd="$JAVA_HOME/bin/java"
+addJava () {
+  vlog "[addJava] arg = '$1'"
+  java_args+=("$1")
+}
+addSbt () {
+  vlog "[addSbt] arg = '$1'"
+  sbt_commands+=("$1")
+}
+setThisBuild () {
+  vlog "[addBuild] args = '$@'"
+  local key="$1" && shift
+  addSbt "set $key in ThisBuild := $@"
+}
+addScalac () {
+  vlog "[addScalac] arg = '$1'"
+  scalac_args+=("$1")
+}
+addResidual () {
+  vlog "[residual] arg = '$1'"
+  residual_args+=("$1")
+}
+addResolver () {
+  addSbt "set resolvers += $1"
+}
+addDebugger () {
+  addJava "-Xdebug"
+  addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
+}
+setScalaVersion () {
+  [[ "$1" == *"-SNAPSHOT" ]] && addResolver 'Resolver.sonatypeRepo("snapshots")'
+  addSbt "++ $1"
+}
+setJavaHome () {
+  java_cmd="$1/bin/java"
+  setThisBuild javaHome "Some(file(\"$1\"))"
+  export JAVA_HOME="$1"
+  export JDK_HOME="$1"
+  export PATH="$JAVA_HOME/bin:$PATH"
+}
+setJavaHomeQuietly () {
+  addSbt warn
+  setJavaHome "$1"
+  addSbt info
+}
 
-# use ~/.sbt/launch to store sbt jars if script_dir is not writable
-[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$HOME/.sbt/launch"
+# if set, use JDK_HOME/JAVA_HOME over java found in path
+if [[ -e "$JDK_HOME/lib/tools.jar" ]]; then
+  setJavaHomeQuietly "$JDK_HOME"
+elif [[ -e "$JAVA_HOME/bin/java" ]]; then
+  setJavaHomeQuietly "$JAVA_HOME"
+fi
+
+# directory to store sbt launchers
+declare sbt_launch_dir="$HOME/.sbt/launchers"
+[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
+
+java_version () {
+  local version=$("$java_cmd" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \")
+  vlog "Detected Java version: $version"
+  echo "${version:2:1}"
+}
+
+# MaxPermSize critical on pre-8 jvms but incurs noisy warning on 8+
+default_jvm_opts () {
+  local v="$(java_version)"
+  if [[ $v -ge 8 ]]; then
+    echo "$default_jvm_opts_common"
+  else
+    echo "-XX:MaxPermSize=384m $default_jvm_opts_common"
+  fi
+}
 
 build_props_scala () {
-  if [[ -r project/build.properties ]]; then
-    versionLine=$(grep ^build.scala.versions project/build.properties)
-    versionString=${versionLine##build.scala.versions=}
-    echo ${versionString%% .*}
+  if [[ -r "$buildProps" ]]; then
+    versionLine="$(grep '^build.scala.versions' "$buildProps")"
+    versionString="${versionLine##build.scala.versions=}"
+    echo "${versionString%% .*}"
   fi
 }
 
 execRunner () {
   # print the arguments one to a line, quoting any containing spaces
-  [[ $verbose || $debug ]] && echo "# Executing command line:" && {
+  vlog "# Executing command line:" && {
     for arg; do
       if [[ -n "$arg" ]]; then
         if printf "%s\n" "$arg" | grep -q ' '; then
-          printf "\"%s\"\n" "$arg"
+          printf >&2 "\"%s\"\n" "$arg"
         else
-          printf "%s\n" "$arg"
+          printf >&2 "%s\n" "$arg"
         fi
       fi
     done
-    echo ""
+    vlog ""
   }
 
-  if [[ -n $batch ]]; then
-    # the only effective way I've found to avoid sbt hanging when backgrounded.
-    exec 0<&-
-    ( "$@" & )
-    # I'm sure there's some way to get our hands on the pid and wait for it
-    # but it exceeds my present level of ambition.
-  else
-    exec "$@"
-  fi
-}
-
-sbt_groupid () {
-  case $(sbt_version) in
-        0.7.*) echo org.scala-tools.sbt ;;
-       0.10.*) echo org.scala-tools.sbt ;;
-    0.11.[12]) echo org.scala-tools.sbt ;;
-            *) echo org.scala-sbt ;;
-  esac
-}
-
-sbt_artifactory_list () {
-  local version0=$(sbt_version)
-  local version=${version0%-SNAPSHOT}
-  local url="http://typesafe.artifactoryonline.com/typesafe/ivy-snapshots/$(sbt_groupid)/sbt-launch/"
-  dlog "Looking for snapshot list at: $url "
-
-  curl -s --list-only "$url" | \
-    grep -F $version | \
-    perl -e 'print reverse <>' | \
-    perl -pe 's#^<a href="([^"/]+).*#$1#;'
-}
-
-make_release_url () {
-  make_url $(sbt_groupid) releases $(sbt_version)
-}
-
-# argument is e.g. 0.13.0-SNAPSHOT
-# finds the actual version (with the build id) at artifactory
-make_snapshot_url () {
-  for ver in $(sbt_artifactory_list); do
-    local url=$(make_url $(sbt_groupid) snapshots $ver)
-    dlog "Testing $url"
-    curl -s --head "$url" >/dev/null
-    dlog "curl returned: $?"
-    echo "$url"
-    return
-  done
+  [[ -n "$batch" ]] && exec </dev/null
+  exec "$@"
 }
 
 jar_url () {
-  case $(sbt_version) in
-             0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-0.7.7.jar" ;;
-        *-SNAPSHOT) make_snapshot_url ;;
-                 *) make_release_url ;;
-  esac
+  make_url "$1"
 }
 
 jar_file () {
@@ -214,13 +238,13 @@ download_url () {
   local url="$1"
   local jar="$2"
 
-  echo "Downloading sbt launcher $(sbt_version):"
-  echo "  From  $url"
-  echo "    To  $jar"
+  echoerr "Downloading sbt launcher for $sbt_version:"
+  echoerr "  From  $url"
+  echoerr "    To  $jar"
 
-  mkdir -p $(dirname "$jar") && {
+  mkdir -p "${jar%/*}" && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi
@@ -228,8 +252,8 @@ download_url () {
 }
 
 acquire_sbt_jar () {
-  sbt_url="$(jar_url)"
-  sbt_jar="$(jar_file $(sbt_version))"
+  sbt_url="$(jar_url "$sbt_version")"
+  sbt_jar="$(jar_file "$sbt_version")"
 
   [[ -r "$sbt_jar" ]] || download_url "$sbt_url" "$sbt_jar"
 }
@@ -238,11 +262,23 @@ usage () {
   cat <<EOM
 Usage: $script_name [options]
 
+Note that options which are passed along to sbt begin with -- whereas
+options to this runner use a single dash. Any sbt command can be scheduled
+to run first by prefixing the command with --, so --warn, --error and so on
+are not special.
+
+Output filtering: if there is a file in the home directory called .sbtignore
+and this is not an interactive sbt session, the file is treated as a list of
+bash regular expressions. Output lines which match any regex are not echoed.
+One can see exactly which lines would have been suppressed by starting this
+runner with the -x option.
+
   -h | -help         print this message
-  -v | -verbose      this runner is chattier
-  -d | -debug        set sbt log level to Debug
-  -q | -quiet        set sbt log level to Error
+  -v                 verbose operation (this runner is chattier)
+  -d, -w, -q         aliases for --debug, --warn, --error (q means quiet)
+  -x                 debug this script
   -trace <level>     display stack traces with a max of <level> frames (default: -1, traces suppressed)
+  -debug-inc         enable debugging log for the incremental compiler
   -no-colors         disable ANSI color codes
   -sbt-create        start sbt even if current directory contains no sbt project
   -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt/<version>)
@@ -254,67 +290,43 @@ Usage: $script_name [options]
   -batch             Disable interactive mode
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
 
-  # sbt version (default: from project/build.properties if present, else latest release)
-  !!! The only way to accomplish this pre-0.12.0 if there is a build.properties file which
-  !!! contains an sbt.version property is to update the file on disk.  That's what this does.
-  -sbt-version  <version>   use the specified version of sbt
+  # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
+  -sbt-force-latest         force the use of the latest release of sbt: $sbt_release_version
+  -sbt-version  <version>   use the specified version of sbt (default: $sbt_release_version)
+  -sbt-dev                  use the latest pre-release version of sbt: $sbt_unreleased_version
   -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-snapshot             use a snapshot version of sbt
-  -sbt-launch-dir <path>    directory to hold sbt launchers (default: $sbt_launch_dir)
+  -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
+  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: $sbt_launch_repo)
 
   # scala version (default: as chosen by sbt)
   -28                       use $latest_28
   -29                       use $latest_29
   -210                      use $latest_210
+  -211                      use $latest_211
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies
 
-  # java version (default: java from PATH, currently $(java -version |& grep version))
+  # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
   -java-home <path>         alternate JAVA_HOME
 
   # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
   # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
-  <default>        $default_jvm_opts
-  JVM_OPTS         environment variable holding jvm args
+  <default>        $(default_jvm_opts)
+  JVM_OPTS         environment variable holding either the jvm args directly, or
+                   the reference to a file containing jvm args if given path is prepended by '@' (e.g. '@/etc/jvmopts')
+                   Note: "@"-file is overridden by local '.jvmopts' or '-jvm-opts' argument.
   -jvm-opts <path> file containing jvm args (if not given, .jvmopts in project root is used if present)
   -Dkey=val        pass -Dkey=val directly to the jvm
   -J-X             pass option -X directly to the jvm (-J is stripped)
 
   # passing options to sbt, OR to this runner
-  SBT_OPTS         environment variable holding sbt args
+  SBT_OPTS         environment variable holding either the sbt args directly, or
+                   the reference to a file containing sbt args if given path is prepended by '@' (e.g. '@/etc/sbtopts')
+                   Note: "@"-file is overridden by local '.sbtopts' or '-sbt-opts' argument.
   -sbt-opts <path> file containing sbt args (if not given, .sbtopts in project root is used if present)
   -S-X             add -X to sbt's scalacOptions (-S is stripped)
 EOM
-}
-
-addJava () {
-  dlog "[addJava] arg = '$1'"
-  java_args=( "${java_args[@]}" "$1" )
-}
-addSbt () {
-  dlog "[addSbt] arg = '$1'"
-  sbt_commands=( "${sbt_commands[@]}" "$1" )
-}
-addScalac () {
-  dlog "[addScalac] arg = '$1'"
-  scalac_args=( "${scalac_args[@]}" "$1" )
-}
-addResidual () {
-  dlog "[residual] arg = '$1'"
-  residual_args=( "${residual_args[@]}" "$1" )
-}
-addResolver () {
-  addSbt "set resolvers in ThisBuild += $1"
-}
-addDebugger () {
-  addJava "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
-}
-setScalaVersion () {
-  addSbt "set scalaVersion in ThisBuild := \"$1\""
-  if [[ "$1" == *SNAPSHOT* ]]; then
-    addResolver Opts.resolver.sonatypeSnapshots
-  fi
 }
 
 process_args ()
@@ -330,84 +342,107 @@ process_args ()
   }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-       -h|-help) usage; exit 1 ;;
-    -v|-verbose) verbose=true && log_level=Info && shift ;;
-      -d|-debug) debug=true && log_level=Debug && shift ;;
-      -q|-quiet) quiet=true && log_level=Error && shift ;;
+          -h|-help) usage; exit 1 ;;
+                -v) verbose=true && shift ;;
+                -d) addSbt "--debug" && addSbt debug && shift ;;
+                -w) addSbt "--warn"  && addSbt warn  && shift ;;
+                -q) addSbt "--error" && addSbt error && shift ;;
+                -x) debugUs=true && shift ;;
+            -trace) require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
+              -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
+        -no-colors) addJava "-Dsbt.log.noformat=true" && shift ;;
+         -no-share) noshare=true && shift ;;
+         -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
+          -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
+        -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
+          -offline) addSbt "set offline := true" && shift ;;
+        -jvm-debug) require_arg port "$1" "$2" && addDebugger "$2" && shift 2 ;;
+            -batch) batch=true && shift ;;
+           -prompt) require_arg "expr" "$1" "$2" && setThisBuild shellPrompt "(s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
 
-         -trace) require_arg integer "$1" "$2" && trace_level=$2 && shift 2 ;;
-           -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
-     -no-colors) addJava "-Dsbt.log.noformat=true" && shift ;;
-      -no-share) noshare=true && shift ;;
-      -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
-       -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
-     -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
-       -offline) addSbt "set offline := true" && shift ;;
-     -jvm-debug) require_arg port "$1" "$2" && addDebugger $2 && shift 2 ;;
-         -batch) batch=true && shift ;;
-        -prompt) require_arg "expr" "$1" "$2" && addSbt "set shellPrompt in ThisBuild := (s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
+       -sbt-create) sbt_create=true && shift ;;
+          -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
+      -sbt-version) require_arg version "$1" "$2" && sbt_explicit_version="$2" && shift 2 ;;
+ -sbt-force-latest) sbt_explicit_version="$sbt_release_version" && shift ;;
+          -sbt-dev) sbt_explicit_version="$sbt_unreleased_version" && shift ;;
+   -sbt-launch-dir) require_arg path "$1" "$2" && sbt_launch_dir="$2" && shift 2 ;;
+  -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
+    -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
+   -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
+       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "Some(file(\"$2\"))" && shift 2 ;;
+        -java-home) require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
+         -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
+         -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
 
-    -sbt-create) sbt_create=true && shift ;;
-  -sbt-snapshot) sbt_explicit_version=$sbt_snapshot_version && shift ;;
-       -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
-   -sbt-version) require_arg version "$1" "$2" && sbt_explicit_version="$2" && shift 2 ;;
--sbt-launch-dir) require_arg path "$1" "$2" && sbt_launch_dir="$2" && shift 2 ;;
- -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
--binary-version) require_arg version "$1" "$2" && addSbt "set scalaBinaryVersion in ThisBuild := \"$2\"" && shift 2 ;;
-    -scala-home) require_arg path "$1" "$2" && addSbt "set every scalaHome := Some(file(\"$2\"))" && shift 2 ;;
-     -java-home) require_arg path "$1" "$2" && java_cmd="$2/bin/java" && shift 2 ;;
-      -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
-      -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
+               -D*) addJava "$1" && shift ;;
+               -J*) addJava "${1:2}" && shift ;;
+               -S*) addScalac "${1:2}" && shift ;;
+               -28) setScalaVersion "$latest_28" && shift ;;
+               -29) setScalaVersion "$latest_29" && shift ;;
+              -210) setScalaVersion "$latest_210" && shift ;;
+              -211) setScalaVersion "$latest_211" && shift ;;
 
-            -D*) addJava "$1" && shift ;;
-            -J*) addJava "${1:2}" && shift ;;
-            -S*) addScalac "${1:2}" && shift ;;
-            -28) addSbt "++ $latest_28" && shift ;;
-            -29) addSbt "++ $latest_29" && shift ;;
-           -210) addSbt "++ $latest_210" && shift ;;
-
-              *) addResidual "$1" && shift ;;
+           --debug) addSbt debug && addResidual "$1" && shift ;;
+            --warn) addSbt warn  && addResidual "$1" && shift ;;
+           --error) addSbt error && addResidual "$1" && shift ;;
+                 *) addResidual "$1" && shift ;;
     esac
   done
 }
 
-
 # process the direct command line arguments
 process_args "$@"
+
+# skip #-styled comments and blank lines
+readConfigFile() {
+  while read line; do
+    [[ $line =~ ^# ]] || [[ -z $line ]] || echo "$line"
+  done < "$1"
+}
 
 # if there are file/environment sbt_opts, process again so we
 # can supply args to this runner
 if [[ -r "$sbt_opts_file" ]]; then
-  readarray -t extra_sbt_opts < "$sbt_opts_file"
-elif [[ -n "$SBT_OPTS" ]]; then
+  vlog "Using sbt options defined in file $sbt_opts_file"
+  while read opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
+elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
+  vlog "Using sbt options defined in variable \$SBT_OPTS"
   extra_sbt_opts=( $SBT_OPTS )
+else
+  vlog "No extra sbt options have been defined"
 fi
 
-[[ -n $extra_sbt_opts ]] && process_args "${extra_sbt_opts[@]}"
+[[ -n "${extra_sbt_opts[*]}" ]] && process_args "${extra_sbt_opts[@]}"
 
 # reset "$@" to the residual args
 set -- "${residual_args[@]}"
 argumentCount=$#
 
+# set sbt version
+set_sbt_version
+
 # only exists in 0.12+
 setTraceLevel() {
-  case $(sbt_version) in
-     0.{7,10,11}.*) echoerr "Cannot set trace level in sbt version $(sbt_version)" ;;
-                 *) addSbt "set every traceLevel := $trace_level" ;;
+  case "$sbt_version" in
+    "0.7."* | "0.10."* | "0.11."* ) echoerr "Cannot set trace level in sbt version $sbt_version" ;;
+                                 *) setThisBuild traceLevel $trace_level ;;
   esac
 }
 
 # set scalacOptions if we were given any -S opts
 [[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
 
-# Update build.properties no disk to set explicit version - sbt gives us no choice
+# Update build.properties on disk to set explicit version - sbt gives us no choice
 [[ -n "$sbt_explicit_version" ]] && update_build_props_sbt "$sbt_explicit_version"
-echoerr "Detected sbt version $(sbt_version)"
+vlog "Detected sbt version $sbt_version"
 
-[[ -n "$scala_version" ]] && echo "Overriding scala version to $scala_version"
+[[ -n "$scala_version" ]] && vlog "Overriding scala version to $scala_version"
 
 # no args - alert them there's stuff in here
-(( $argumentCount > 0 )) || echo "Starting $script_name: invoke with -help for other options"
+(( argumentCount > 0 )) || {
+  vlog "Starting $script_name: invoke with -help for other options"
+  residual_args=( shell )
+}
 
 # verify this is an sbt dir or -create was given
 [[ -r ./build.sbt || -d ./project || -n "$sbt_create" ]] || {
@@ -430,37 +465,79 @@ EOM
   exit 1
 }
 
-if [[ -n $noshare ]]; then
-  addJava "$noshare_opts"
+if [[ -n "$noshare" ]]; then
+  for opt in ${noshare_opts}; do
+    addJava "$opt"
+  done
 else
-  [[ -n "$sbt_dir" ]] || {
-    sbt_dir=~/.sbt/$(sbt_version)
-    vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."
-  }
-  addJava "-Dsbt.global.base=$sbt_dir"
+  case "$sbt_version" in
+    "0.7."* | "0.10."* | "0.11."* | "0.12."* )
+      [[ -n "$sbt_dir" ]] || {
+        sbt_dir="$HOME/.sbt/$sbt_version"
+        vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."
+      }
+    ;;
+  esac
+
+  if [[ -n "$sbt_dir" ]]; then
+    addJava "-Dsbt.global.base=$sbt_dir"
+  fi
 fi
 
 if [[ -r "$jvm_opts_file" ]]; then
-  readarray -t extra_jvm_opts < "$jvm_opts_file"
-elif [[ -n "$JVM_OPTS" ]]; then
+  vlog "Using jvm options defined in file $jvm_opts_file"
+  while read opt; do extra_jvm_opts+=("$opt"); done < <(readConfigFile "$jvm_opts_file")
+elif [[ -n "$JVM_OPTS" && ! ("$JVM_OPTS" =~ ^@.*) ]]; then
+  vlog "Using jvm options defined in \$JVM_OPTS variable"
   extra_jvm_opts=( $JVM_OPTS )
 else
-  extra_jvm_opts=( $default_jvm_opts )
+  vlog "Using default jvm options"
+  extra_jvm_opts=( $(default_jvm_opts) )
 fi
 
-# since sbt 0.7 doesn't understand iflast
-[[ ${#residual_args[@]} -eq 0 ]] && [[ -z "$batch" ]] && residual_args=( "shell" )
-
 # traceLevel is 0.12+
-[[ -n $trace_level ]] && setTraceLevel
+[[ -n "$trace_level" ]] && setTraceLevel
 
-[[ -n $log_level ]] && [[ $log_level != Info ]] && logLevalArg="set logLevel in Global := Level.$log_level"
+main () {
+  execRunner "$java_cmd" \
+    "${extra_jvm_opts[@]}" \
+    "${java_args[@]}" \
+    -jar "$sbt_jar" \
+    "${sbt_commands[@]}" \
+    "${residual_args[@]}"
+}
+
+# sbt inserts this string on certain lines when formatting is enabled:
+#   val OverwriteLine = "\r\u001BM\u001B[2K"
+# ...in order not to spam the console with a million "Resolving" lines.
+# Unfortunately that makes it that much harder to work with when
+# we're not going to print those lines anyway. We strip that bit of
+# line noise, but leave the other codes to preserve color.
+mainFiltered () {
+  local ansiOverwrite='\r\x1BM\x1B[2K'
+  local excludeRegex=$(egrep -v '^#|^$' ~/.sbtignore | paste -sd'|' -)
+
+  echoLine () {
+    local line="$1"
+    local line1="$(echo "$line" | sed -r 's/\r\x1BM\x1B\[2K//g')"       # This strips the OverwriteLine code.
+    local line2="$(echo "$line1" | sed -r 's/\x1B\[[0-9;]*[JKmsu]//g')" # This strips all codes - we test regexes against this.
+
+    if [[ $line2 =~ $excludeRegex ]]; then
+      [[ -n $debugUs ]] && echo "[X] $line1"
+    else
+      [[ -n $debugUs ]] && echo "    $line1" || echo "$line1"
+    fi
+  }
+
+  echoLine "Starting sbt with output filtering enabled."
+  main | while read -r line; do echoLine "$line"; done
+}
+
+# Only filter if there's a filter file and we don't see a known interactive command.
+# Obviously this is super ad hoc but I don't know how to improve on it. Testing whether
+# stdin is a terminal is useless because most of my use cases for this filtering are
+# exactly when I'm at a terminal, running sbt non-interactively.
+shouldFilter () { [[ -f ~/.sbtignore ]] && ! egrep -q '\b(shell|console|consoleProject)\b' <<<"${residual_args[@]}"; }
 
 # run sbt
-execRunner "$java_cmd" \
-  "${extra_jvm_opts[@]}" \
-  "${java_args[@]}" \
-  -jar "$sbt_jar" \
-  "$logLevalArg" \
-  "${sbt_commands[@]}" \
-  "${residual_args[@]}"
+if shouldFilter; then mainFiltered; else main; fi


### PR DESCRIPTION
The main use for now is to upload application statistics as a batch of metrics.

There are a few subtleties around the "strategies" for setting dimensions on metric data points:

 - `setAllDimensions` forces a list of dimensions on each point

 - `setDimensionsPrefixes` takes a list of dimensions and sets a list of prefixes on each data point. This allows to see each point at different "aggregation levels" like: `env/client/app`, `env/client`, `env`

 - `extendLongestPrefix` when we want to add one more piece of information on the longuest prefix, for example `env/client/app/job-id` (but we don't want to create `env/client/job-id` or just `job-id` as dimensions)